### PR TITLE
Add homepage widget guide

### DIFF
--- a/app/i18n/locales/en/translation.json
+++ b/app/i18n/locales/en/translation.json
@@ -189,5 +189,23 @@
   },
   "testimonialsAvatars": {
     "joinAndGetDiscount": "Join our <1>{{subscriberCount}}</1> subscribers and get <3>40% off</3> when launch!"
+  },
+  "howItWorks": {
+    "eyebrow": "How it works?",
+    "title": "Find value in 3 steps",
+    "steps": [
+      {
+        "title": "Install Feedbackito script",
+        "description": "Copy a tiny script tag into your site. It loads fast and works anywhere."
+      },
+      {
+        "title": "Create your first survey",
+        "description": "Pick a template or start from scratch. Launch in minutes from the dashboard."
+      },
+      {
+        "title": "Analyze results",
+        "description": "See responses, AI summaries and recommended actions to improve."
+      }
+    ]
   }
 } 

--- a/app/i18n/locales/es/translation.json
+++ b/app/i18n/locales/es/translation.json
@@ -189,5 +189,23 @@
   },
   "testimonialsAvatars": {
     "joinAndGetDiscount": "¡Únete a nuestros <1>{{subscriberCount}}</1> suscriptores y obtén un <3>40% de descuento</3> en el lanzamiento!"
+  },
+  "howItWorks": {
+    "eyebrow": "¿Cómo funciona?",
+    "title": "Descubre valor en 3 pasos",
+    "steps": [
+      {
+        "title": "Instala el script de Feedbackito",
+        "description": "Copia una etiqueta de script mínima en tu sitio. Carga rápido y funciona en cualquier lugar."
+      },
+      {
+        "title": "Crea tu primera encuesta",
+        "description": "Elige una plantilla o empieza desde cero. Lanza en minutos desde el panel."
+      },
+      {
+        "title": "Analiza los resultados",
+        "description": "Mira respuestas, resúmenes con IA y acciones recomendadas para mejorar."
+      }
+    ]
   }
 } 

--- a/app/page.js
+++ b/app/page.js
@@ -11,6 +11,7 @@ import Footer from "@/components/Footer";
 import Problem from "@/components/Problem";
 import FeaturesAccordion from "@/components/FeaturesAccordion";
 import CardUseCases from "@/components/CardUseCases";
+import CardHowItWorks from "@/components/CardHowItWorks";
 import { cookies } from "next/headers";
 
 
@@ -28,6 +29,7 @@ export default async function Page() {
         <HeroSection lang={lng}/>
         <Problem lang={lng}/> 
         <FeaturesAccordion lang={lng}/>
+        <CardHowItWorks lang={lng} />
         <CardUseCases lang={lng} />
         <Pricing lang={lng}/>
         <PricingComparison lang={lng}/>

--- a/components/CardHowItWorks.jsx
+++ b/components/CardHowItWorks.jsx
@@ -1,0 +1,42 @@
+import { cookies } from "next/headers";
+import { useTranslation as getTranslation } from "@/app/i18n";
+import Card from "@/components/ui/card";
+
+export default async function CardHowItWorks({ lang }) {
+  const lng = lang || (await cookies()).get("i18next")?.value || "en";
+  const { t } = await getTranslation(lng);
+
+  const steps = t("howItWorks.steps", { returnObjects: true });
+
+  return (
+    <section className="py-24 md:py-32 bg-base-100">
+      <div className="max-w-7xl mx-auto px-8">
+        <p className="text-sm font-semibold tracking-widest uppercase text-primary mb-2">
+          {t("howItWorks.eyebrow")}
+        </p>
+        <h2 className="font-extrabold text-4xl lg:text-6xl tracking-tight mb-4">
+          {t("howItWorks.title")}
+        </h2>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 md:gap-8 mt-8">
+          {Array.isArray(steps) && steps.map((step, idx) => (
+            <Card key={idx} className="border border-base-200 hover:shadow-2xl transition-shadow">
+              <div className="p-6 md:p-8 h-full flex flex-col">
+                <div className="flex items-start gap-4 mb-4">
+                  <span className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-primary text-primary-content font-bold">
+                    {idx + 1}
+                  </span>
+                  <h3 className="text-xl font-semibold leading-snug">
+                    {step.title}
+                  </h3>
+                </div>
+                <p className="text-base-content/70 leading-relaxed flex-1">{step.description}</p>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
Add a "How it works" 3-step section to the homepage to guide users on widget usage (FEE-10).

---
Linear Issue: [FEE-10](https://linear.app/feedbackito/issue/FEE-10/add-card-of-how-it-works-on-the-homepage)

<a href="https://cursor.com/background-agent?bcId=bc-a44bf952-8bef-43cc-98d4-c81283c69376">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a44bf952-8bef-43cc-98d4-c81283c69376">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

