### PR TITLE
Fix Spanish translation display bug on small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,9 @@ progress::-webkit-progress-value {
   transform: rotate(180deg);
 }
 
+/* Ensure highlight backgrounds hug glyphs on small screens */
+.bg-neutral.inline-block { padding-left: 0; padding-right: 0; }
+
 /*
 @layer base {
   .btn-gradient {

--- a/components/CardUseCases.jsx
+++ b/components/CardUseCases.jsx
@@ -12,7 +12,7 @@ export default async function CardUseCases({ lang }) {
     <section className="py-24 md:py-32 bg-base-100">
       <div className="max-w-7xl mx-auto px-8">
         <h2 className="font-extrabold text-4xl lg:text-6xl tracking-tight mb-4">
-          {t("useCases.title")} <span className="bg-neutral text-neutral-content px-2 md:px-4 ml-1 md:ml-1.5 leading-relaxed whitespace-nowrap">{t("useCases.titleHighlight")}</span>
+          {t("useCases.title")} <span className="bg-neutral text-neutral-content px-2 md:px-4 ml-1 md:ml-1.5 leading-relaxed inline-block whitespace-normal md:whitespace-nowrap break-words">{t("useCases.titleHighlight")}</span>
         </h2>
         <p className="text-base-content/70 mb-10 md:mb-14 max-w-3xl">{t("useCases.subtitle")}</p>
 

--- a/components/CardUseCases.jsx
+++ b/components/CardUseCases.jsx
@@ -12,7 +12,7 @@ export default async function CardUseCases({ lang }) {
     <section className="py-24 md:py-32 bg-base-100">
       <div className="max-w-7xl mx-auto px-8">
         <h2 className="font-extrabold text-4xl lg:text-6xl tracking-tight mb-4">
-          {t("useCases.title")} <span className="bg-neutral text-neutral-content px-2 md:px-4 ml-1 md:ml-1.5 leading-relaxed inline-block whitespace-normal md:whitespace-nowrap break-words">{t("useCases.titleHighlight")}</span>
+          {t("useCases.title")} <span className="bg-neutral text-neutral-content ml-1 md:ml-1.5 leading-relaxed inline-block whitespace-normal md:whitespace-nowrap break-words">{t("useCases.titleHighlight")}</span>
         </h2>
         <p className="text-base-content/70 mb-10 md:mb-14 max-w-3xl">{t("useCases.subtitle")}</p>
 

--- a/components/FeaturesAccordion.js
+++ b/components/FeaturesAccordion.js
@@ -116,7 +116,7 @@ const FeaturesAccordion = () => {
       <div className="px-8">
         <h2 className="font-extrabold text-4xl lg:text-6xl tracking-tight mb-12 md:mb-24">
           {t('featuresAccordion.title')}{' '}
-          <span className="bg-neutral text-neutral-content px-2 md:px-4 ml-1 md:ml-1.5 leading-relaxed whitespace-nowrap">
+          <span className="bg-neutral text-neutral-content px-2 md:px-4 ml-1 md:ml-1.5 leading-relaxed inline-block whitespace-normal md:whitespace-nowrap break-words">
             {t('featuresAccordion.titleHighlight')}
           </span>
         </h2>

--- a/components/FeaturesAccordion.js
+++ b/components/FeaturesAccordion.js
@@ -116,7 +116,7 @@ const FeaturesAccordion = () => {
       <div className="px-8">
         <h2 className="font-extrabold text-4xl lg:text-6xl tracking-tight mb-12 md:mb-24">
           {t('featuresAccordion.title')}{' '}
-          <span className="bg-neutral text-neutral-content px-2 md:px-4 ml-1 md:ml-1.5 leading-relaxed inline-block whitespace-normal md:whitespace-nowrap break-words">
+          <span className="bg-neutral text-neutral-content ml-1 md:ml-1.5 leading-relaxed inline-block whitespace-normal md:whitespace-nowrap break-words">
             {t('featuresAccordion.titleHighlight')}
           </span>
         </h2>

--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -31,7 +31,7 @@ const HeroSection = () => {
             {t('heroSection.title')}
             <br />
             {" "}
-            <span className="bg-neutral text-neutral-content px-2 md:px-4 ml-1 md:ml-1.5 leading-relaxed whitespace-nowrap">
+            <span className="bg-neutral text-neutral-content px-2 md:px-4 ml-1 md:ml-1.5 leading-relaxed inline-block whitespace-normal md:whitespace-nowrap break-words">
               {t('heroSection.titleHighlight')}
             </span>
           </h1>

--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -31,7 +31,7 @@ const HeroSection = () => {
             {t('heroSection.title')}
             <br />
             {" "}
-            <span className="bg-neutral text-neutral-content px-2 md:px-4 ml-1 md:ml-1.5 leading-relaxed inline-block whitespace-normal md:whitespace-nowrap break-words">
+            <span className="bg-neutral text-neutral-content ml-1 md:ml-1.5 leading-relaxed inline-block whitespace-normal md:whitespace-nowrap break-words">
               {t('heroSection.titleHighlight')}
             </span>
           </h1>


### PR DESCRIPTION
Allow highlighted text to wrap on small screens to fix mobile display overflow in Spanish translation.

---
Linear Issue: [FEE-16](https://linear.app/feedbackito/issue/FEE-16/fix-bug-display-mobile-small-screen-in-spanish-translation)

<a href="https://cursor.com/background-agent?bcId=bc-e174a4e9-824d-4d3f-bf51-4452cf794149">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e174a4e9-824d-4d3f-bf51-4452cf794149">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

